### PR TITLE
feat!: move to `Request` based API

### DIFF
--- a/curl/codegen/codegen.v
+++ b/curl/codegen/codegen.v
@@ -2,10 +2,13 @@
 import net.html
 import vibe
 
-const separator = '\n-----------------------------------------------------------------------\n'
+const (
+	request   = vibe.Request{}
+	separator = '\n-----------------------------------------------------------------------\n'
+)
 
-fn gen_opts(session vibe.Session) string {
-	body := session.get('https://curl.se/libcurl/c/easy_setopt_options.html') or {
+fn gen_opts() string {
+	body := request.get('https://curl.se/libcurl/c/easy_setopt_options.html') or {
 		panic('Error requesting options source: ${err}')
 	}.body
 	mut rows := html.parse(body).get_tag('table')[0].get_tags('tr')
@@ -28,8 +31,8 @@ module state
 ${opts}'
 }
 
-fn gen_codes(session vibe.Session) string {
-	body := session.get('https://curl.se/libcurl/c/libcurl-errors.html') or {
+fn gen_codes() string {
+	body := request.get('https://curl.se/libcurl/c/libcurl-errors.html') or {
 		panic('Error requesting errors source: ${err}')
 	}.body
 	mut doc := html.parse(body)
@@ -80,8 +83,8 @@ ${ue}\n
 ${h}'
 }
 
-fn gen_info(session vibe.Session) string {
-	body := session.get('https://curl.se/libcurl/c/easy_getinfo_options.html') or {
+fn gen_info() string {
+	body := request.get('https://curl.se/libcurl/c/easy_getinfo_options.html') or {
 		panic('Error requesting info options source: ${err}')
 	}.body
 	mut rows := html.parse(body).get_tag('table')[0].get_tags('tr')
@@ -104,13 +107,8 @@ module state
 ${info}'
 }
 
-session := vibe.init_session(vibe.SessionOpts{})!
-defer {
-	session.close()
-}
-
-println(gen_opts(session))
+println(gen_opts())
 println(separator)
-println(gen_codes(session))
+println(gen_codes())
 println(separator)
-println(gen_info(session))
+println(gen_info())

--- a/src/_instruction_download.v
+++ b/src/_instruction_download.v
@@ -3,9 +3,18 @@ module vibe
 import os
 import vibe.curl
 
-fn (s Session) download_file_(url string, file_path string) !Response {
-	mut resp := s.get_head(url)!
+fn (req Request) download_file_(url string, file_path string) !Response {
+	h := curl.easy_init() or { return IError(HttpError{
+		kind: .session_init
+	}) }
+	header := set_header(req.headers, h)
+	defer {
+		curl.easy_cleanup(h)
+		curl.slist_free_all(header)
+	}
 
+	// Follows redirects, updates the url to the redirected target and sets header data.
+	mut resp := req.get_head(h, url)!
 	mut file := os.create(file_path)!
 	defer {
 		file.close()
@@ -13,18 +22,34 @@ fn (s Session) download_file_(url string, file_path string) !Response {
 	mut fw := FileWriter{
 		file: file
 	}
-
-	curl.easy_setopt(s.curl, .header, 0)
-	curl.easy_setopt(s.curl, .writefunction, write_download)
-	curl.easy_setopt(s.curl, .writedata, &fw)
-
-	send_request(s.curl)!
+	curl.easy_setopt(h, .header, 0)
+	curl.easy_setopt(h, .writefunction, write_download)
+	curl.easy_setopt(h, .writedata, &fw)
+	send_request(h)!
 
 	mut status_code := 0
-	curl.easy_getinfo(s.curl, .response_code, &status_code)
-
+	curl.easy_getinfo(h, .response_code, &status_code)
 	resp.status = Status(status_code)
 	resp.get_http_version()!
+
+	return resp
+}
+
+// HEAD requests often fail due to being unauthenticated.
+// Performing a get request that omits the body to get information about the head can be a workaround.
+// For now this function is for internal usage, e.g. in conjunction with downloading.
+fn (req Request) get_head(h &C.CURL, url string) !Response {
+	mut resp := Response{}
+	req.set_get_opts(h, url, &resp)
+	curl.easy_setopt(h, .writefunction, write_null)
+	curl.easy_setopt(h, .writedata, unsafe { nil })
+	send_request(h)!
+
+	mut status_code := 0
+	curl.easy_getinfo(h, .response_code, &status_code)
+	if status_code / 100 == 3 {
+		resp.handle_redirect(h, req.max_redirects)!
+	}
 
 	return resp
 }

--- a/src/_instruction_download.v
+++ b/src/_instruction_download.v
@@ -5,7 +5,7 @@ import vibe.curl
 
 fn (req Request) download_file_(url string, file_path string) !Response {
 	h := curl.easy_init() or { return IError(HttpError{
-		kind: .session_init
+		kind: .easy_init
 	}) }
 	header := set_header(req.headers, h)
 	defer {

--- a/src/_instructions_common.v
+++ b/src/_instructions_common.v
@@ -2,9 +2,21 @@ module vibe
 
 import vibe.curl
 
-fn init_session_(opts SessionOpts) !Session {
+// Automatically call curl_global_init when using `vibe`.
+fn init() {
 	curl.global_init(.default)
+}
 
+fn custom_init_(flag CustomInitFlag) {
+	curl.global_cleanup()
+	curl.global_init(flag)
+}
+
+fn cleanup_() {
+	curl.global_cleanup()
+}
+
+fn init_session_(opts SessionOpts) !Session {
 	// Curl handle
 	h := curl.easy_init() or { return IError(HttpError{
 		kind: .session_init
@@ -45,7 +57,6 @@ fn (s &Session) set_opts() {
 fn (s &Session) close_() {
 	curl.slist_free_all(s.header_list)
 	curl.easy_cleanup(s.curl)
-	curl.global_cleanup()
 }
 
 fn (s &Session) set_request_opts(method Method, resp &Response, url string) {

--- a/src/_instructions_common.v
+++ b/src/_instructions_common.v
@@ -16,79 +16,19 @@ fn cleanup_() {
 	curl.global_cleanup()
 }
 
-fn init_session_(opts SessionOpts) !Session {
-	// Curl handle
-	h := curl.easy_init() or { return IError(HttpError{
-		kind: .session_init
-	}) }
-
-	s := Session{
-		SessionOpts: opts
-		curl: h
-		header_list: set_header(opts.headers, h)
+fn (req Request) set_common_opts(h &C.CURL, url string, resp &Response) {
+	if req.cookie_jar != '' {
+		curl.easy_setopt(h, .cookiejar, req.cookie_jar)
 	}
-
-	s.set_opts()
-
-	return s
-}
-
-fn (s &Session) set_opts() {
-	if s.cookie_session {
-		curl.easy_setopt(s.curl, .cookiesession, 1)
+	if req.cookie_file != '' {
+		curl.easy_setopt(h, .cookiefile, req.cookie_file)
 	}
-	if s.cookie_jar != '' {
-		curl.easy_setopt(s.curl, .cookiejar, s.cookie_jar)
+	if req.timeout > 0 {
+		curl.easy_setopt(h, .timeout_ms, req.timeout.milliseconds())
 	}
-	if s.cookie_file != '' {
-		curl.easy_setopt(s.curl, .cookiefile, s.cookie_file)
-	}
-	if s.timeout > 0 {
-		curl.easy_setopt(s.curl, .timeout_ms, s.timeout.milliseconds())
-	}
-
-	curl.easy_setopt(s.curl, .headerfunction, write_resp_header)
-
-	$if curl_verbose ? {
-		curl.easy_setopt(s.curl, .verbose, 1)
-	}
-}
-
-fn (s &Session) close_() {
-	curl.slist_free_all(s.header_list)
-	curl.easy_cleanup(s.curl)
-}
-
-fn (s &Session) set_request_opts(method Method, resp &Response, url string) {
-	// Individual
-	match method {
-		.get {
-			curl.easy_setopt(s.curl, .httpget, 1)
-		}
-		.post {
-			curl.easy_setopt(s.curl, .post, 1)
-		}
-		.head {
-			curl.easy_setopt(s.curl, .header, 0)
-			curl.easy_setopt(s.curl, .nobody, 1)
-		}
-	}
-
-	// Partially shared
-	if method != .head {
-		curl.easy_setopt(s.curl, .nobody, 0)
-		curl.easy_setopt(s.curl, .header, 1)
-		curl.easy_setopt(s.curl, .writedata, resp)
-		if resp.slice.start > 0 {
-			curl.easy_setopt(s.curl, .writefunction, write_resp_slice)
-		} else {
-			curl.easy_setopt(s.curl, .writefunction, write_resp)
-		}
-	}
-
-	// Shared
-	curl.easy_setopt(s.curl, .url, url)
-	curl.easy_setopt(s.curl, .headerdata, resp)
+	curl.easy_setopt(h, .url, url)
+	curl.easy_setopt(h, .headerdata, resp)
+	curl.easy_setopt(h, .headerfunction, write_resp_header)
 }
 
 fn send_request(handle &C.CURL) ! {
@@ -100,16 +40,16 @@ fn send_request(handle &C.CURL) ! {
 	}
 }
 
-fn (s Session) handle_redirect(mut resp Response) ! {
+fn (mut resp Response) handle_redirect(h &C.CURL, max_redirects u16) ! {
 	mut status_code := 0
 	mut redir_url := ''.str
 
-	for _ in 0 .. s.max_redirects {
+	for _ in 0 .. max_redirects {
 		resp = Response{}
-		curl.easy_getinfo(s.curl, .redirect_url, &redir_url)
-		curl.easy_setopt(s.curl, .url, redir_url)
-		send_request(s.curl)!
-		curl.easy_getinfo(s.curl, .response_code, &status_code)
+		curl.easy_getinfo(h, .redirect_url, &redir_url)
+		curl.easy_setopt(h, .url, redir_url)
+		send_request(h)!
+		curl.easy_getinfo(h, .response_code, &status_code)
 		if status_code / 100 != 3 {
 			return
 		}

--- a/src/_instructions_get.v
+++ b/src/_instructions_get.v
@@ -2,27 +2,45 @@ module vibe
 
 import vibe.curl
 
-fn (s Session) get_(url string) !Response {
+fn (req Request) get_(url string) !Response {
+	// Curl handle
+	h := curl.easy_init() or { return IError(HttpError{
+		kind: .session_init
+	}) }
+	header := set_header(req.headers, h)
+	defer {
+		curl.easy_cleanup(h)
+		curl.slist_free_all(header)
+	}
+
 	mut resp := Response{}
-
-	s.set_request_opts(.get, &resp, url)
-
-	send_request(s.curl)!
+	req.set_get_opts(h, url, &resp)
+	send_request(h)!
 
 	mut status_code := 0
-	curl.easy_getinfo(s.curl, .response_code, &status_code)
+	curl.easy_getinfo(h, .response_code, &status_code)
 	if status_code / 100 == 3 {
-		s.handle_redirect(mut resp)!
-		curl.easy_getinfo(s.curl, .response_code, &status_code)
+		resp.handle_redirect(h, req.max_redirects)!
+		curl.easy_getinfo(h, .response_code, &status_code)
 	}
 
 	resp.get_http_version()!
 	resp.status = Status(status_code)
 	resp.body = resp.body[resp.header.len..]
+
 	return resp
 }
 
-fn (s Session) get_slice_(url string, start usize, max_size_ ?usize) !Response {
+fn (req Request) get_slice_(url string, start usize, max_size_ ?usize) !Response {
+	h := curl.easy_init() or { return IError(HttpError{
+		kind: .session_init
+	}) }
+	header := set_header(req.headers, h)
+	defer {
+		curl.easy_cleanup(h)
+		curl.slist_free_all(header)
+	}
+
 	max_size := max_size_ or { 0 }
 	mut resp := Response{
 		slice: struct {
@@ -30,10 +48,8 @@ fn (s Session) get_slice_(url string, start usize, max_size_ ?usize) !Response {
 			end: start + max_size
 		}
 	}
-
-	s.set_request_opts(.get, &resp, url)
-
-	res := curl.easy_perform(s.curl)
+	req.set_get_opts(h, url, &resp)
+	res := curl.easy_perform(h)
 	if res != curl.Ecode.ok && !resp.slice.finished {
 		return IError(curl.CurlError{
 			e_code: res
@@ -41,23 +57,23 @@ fn (s Session) get_slice_(url string, start usize, max_size_ ?usize) !Response {
 	}
 
 	mut status_code := 0
-	curl.easy_getinfo(s.curl, .response_code, &status_code)
+	curl.easy_getinfo(h, .response_code, &status_code)
 	if status_code / 100 == 3 {
-		s.handle_redirect(mut resp)!
-		curl.easy_getinfo(s.curl, .response_code, &status_code)
+		resp.handle_redirect(h, req.max_redirects)!
+	} else {
+		resp.status = Status(status_code)
 	}
 
 	if resp.body.len == 0 {
+		slice_end := if max_size == 0 { resp.body.len } else { int(resp.slice.end) }
 		return IError(HttpError{
 			kind: .slice_out_of_range
-			// TODO: handle slice with remainder size in error message
-			val: '${start}..${resp.slice.end}'
+			val: '${start}..${slice_end}'
 		})
 	}
 
 	resp.get_http_version()!
-	resp.status = Status(status_code)
-
+	// resp.status = Status(status_code)
 	if start < resp.header.len {
 		resp.body = resp.body[resp.header.len - int(start)..]
 	}
@@ -66,4 +82,16 @@ fn (s Session) get_slice_(url string, start usize, max_size_ ?usize) !Response {
 	}
 
 	return resp
+}
+
+fn (req Request) set_get_opts(h &C.CURL, url string, resp &Response) {
+	if resp.slice.start > 0 {
+		curl.easy_setopt(h, .writefunction, write_resp_slice)
+	} else {
+		curl.easy_setopt(h, .writefunction, write_resp)
+	}
+	curl.easy_setopt(h, .httpget, 1)
+	curl.easy_setopt(h, .header, 1)
+	curl.easy_setopt(h, .writedata, resp)
+	req.set_common_opts(h, url, resp)
 }

--- a/src/_instructions_get.v
+++ b/src/_instructions_get.v
@@ -5,7 +5,7 @@ import vibe.curl
 fn (req Request) get_(url string) !Response {
 	// Curl handle
 	h := curl.easy_init() or { return IError(HttpError{
-		kind: .session_init
+		kind: .easy_init
 	}) }
 	header := set_header(req.headers, h)
 	defer {
@@ -33,7 +33,7 @@ fn (req Request) get_(url string) !Response {
 
 fn (req Request) get_slice_(url string, start usize, max_size_ ?usize) !Response {
 	h := curl.easy_init() or { return IError(HttpError{
-		kind: .session_init
+		kind: .easy_init
 	}) }
 	header := set_header(req.headers, h)
 	defer {

--- a/src/_instructions_head.v
+++ b/src/_instructions_head.v
@@ -4,7 +4,7 @@ import vibe.curl
 
 fn (req Request) head_(url string) !Response {
 	h := curl.easy_init() or { return IError(HttpError{
-		kind: .session_init
+		kind: .easy_init
 	}) }
 	header := set_header(req.headers, h)
 	defer {

--- a/src/_instructions_post.v
+++ b/src/_instructions_post.v
@@ -2,24 +2,30 @@ module vibe
 
 import vibe.curl
 
-fn (s Session) post_(url string, data string) !Response {
-	mut resp := Response{}
-
-	s.set_request_opts(.post, &resp, url)
-	curl.easy_setopt(s.curl, .postfields, data)
-
-	res := curl.easy_perform(s.curl)
-	if res != curl.Ecode.ok {
-		return IError(curl.CurlError{
-			e_code: res
-		})
+fn (req Request) post_(url string, data string) !Response {
+	h := curl.easy_init() or { return IError(HttpError{
+		kind: .session_init
+	}) }
+	header := set_header(req.headers, h)
+	defer {
+		curl.easy_cleanup(h)
+		curl.slist_free_all(header)
 	}
 
+	mut resp := Response{}
+	curl.easy_setopt(h, .post, 1)
+	curl.easy_setopt(h, .postfields, data)
+	curl.easy_setopt(h, .header, 1)
+	curl.easy_setopt(h, .writedata, &resp)
+	curl.easy_setopt(h, .writefunction, write_resp)
+	req.set_common_opts(h, url, resp)
+	send_request(h)!
+
 	mut status_code := 0
-	curl.easy_getinfo(s.curl, .response_code, &status_code)
+	curl.easy_getinfo(h, .response_code, &status_code)
 	if status_code / 100 == 3 {
-		s.handle_redirect(mut resp)!
-		curl.easy_getinfo(s.curl, .response_code, &status_code)
+		resp.handle_redirect(h, req.max_redirects)!
+		curl.easy_getinfo(h, .response_code, &status_code)
 	}
 
 	resp.get_http_version()!

--- a/src/_instructions_post.v
+++ b/src/_instructions_post.v
@@ -4,7 +4,7 @@ import vibe.curl
 
 fn (req Request) post_(url string, data string) !Response {
 	h := curl.easy_init() or { return IError(HttpError{
-		kind: .session_init
+		kind: .easy_init
 	}) }
 	header := set_header(req.headers, h)
 	defer {

--- a/src/_state_common.v
+++ b/src/_state_common.v
@@ -3,17 +3,10 @@ module vibe
 import time
 import vibe.curl.state
 
-pub struct Session {
-	SessionOpts
-	curl        &C.CURL
-	header_list &HeaderList
-}
-
-pub struct SessionOpts {
+pub struct Request {
 pub mut:
 	headers        map[HttpHeader]string
 	custom_headers map[string]string // TODO:
-	cookie_session bool = true
 	cookie_jar     string
 	cookie_file    string
 	timeout        time.Duration

--- a/src/_state_common.v
+++ b/src/_state_common.v
@@ -1,6 +1,7 @@
 module vibe
 
 import time
+import vibe.curl.state
 
 pub struct Session {
 	SessionOpts
@@ -32,3 +33,7 @@ enum Method {
 	post
 	head
 }
+
+// vfmt off
+pub type CustomInitFlag = state.GlobalInitFlag
+// vfmt on

--- a/src/codegen/codegen.v
+++ b/src/codegen/codegen.v
@@ -2,10 +2,13 @@
 import net.html
 import vibe
 
-const separator = '\n-----------------------------------------------------------------------\n'
+const (
+	request   = vibe.Request{}
+	separator = '\n-----------------------------------------------------------------------\n'
+)
 
-fn gen_headers(session vibe.Session) string {
-	body := session.get_slice('https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers',
+fn gen_headers() string {
+	body := request.get_slice('https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers',
 		25_000, 35_000) or { panic('Error requesting headers source: ${err}') }.body
 	mut lists := html.parse(body).get_tag('details')
 	if lists.len == 0 {
@@ -61,8 +64,8 @@ ${separator}
 ${header_str_method}'
 }
 
-fn gen_status(session vibe.Session) string {
-	body := session.get('https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml') or {
+fn gen_status() string {
+	body := request.get('https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml') or {
 		panic('Error requesting headers source: ${err}')
 	}.body
 	mut rows := html.parse(body).get_tag('table')[0].get_tags('tr')
@@ -89,12 +92,7 @@ fn gen_status(session vibe.Session) string {
 ${status_msg_fn}'
 }
 
-session := vibe.init_session(vibe.SessionOpts{})!
-defer {
-	session.close()
-}
-
 // For now, a manual approach yanking the generated code from stdout will suffice.
-println(gen_headers(session))
+println(gen_headers())
 println(separator)
-println(gen_status(session))
+println(gen_status())

--- a/src/errors.v
+++ b/src/errors.v
@@ -7,7 +7,7 @@ struct HttpError {
 }
 
 enum HttpErrorKind {
-	session_init
+	easy_init
 	slice_out_of_range
 	status_line
 	version
@@ -17,7 +17,7 @@ enum HttpErrorKind {
 
 fn (err HttpError) msg() string {
 	return match err.kind {
-		.session_init { 'Failed initiating session' }
+		.easy_init { 'Failed initiating curl' }
 		.slice_out_of_range { 'Failed finding slice in range: `${err.val}`' }
 		.status_line { 'Failed processing HTTP response - Invalid header status line: `${err.val}`' }
 		.version { 'Failed processing HTTP version: `${err.val}`' }

--- a/src/lib.v
+++ b/src/lib.v
@@ -46,3 +46,13 @@ pub fn (session Session) post(url string, data string) !Response {
 pub fn (status Status) msg() string {
 	return status.msg_()
 }
+
+// Initializes libcurl with a custom flag.
+pub fn custom_init(flag CustomInitFlag) {
+	custom_init_(flag)
+}
+
+// Releases resources that were acquired initializing the underlying libcurl module.
+pub fn cleanup() {
+	cleanup_()
+}

--- a/src/lib.v
+++ b/src/lib.v
@@ -4,42 +4,32 @@ import v.vmod
 
 const manifest = vmod.decode($embed_file('../v.mod').to_string()) or { panic(err) }
 
-// Initializes a new session to send and receive responses.
-pub fn init_session(opts SessionOpts) !Session {
-	return init_session_(opts)!
-}
-
-// Releases resources that the session acquired with the underlying libcurl module.
-pub fn (session Session) close() {
-	session.close_()
-}
-
 // Sends a GET request to the specified `url` and returns the response.
-pub fn (session Session) get(url string) !Response {
-	return session.get_(url)!
+pub fn (req Request) get(url string) !Response {
+	return req.get_(url)!
 }
 
 // Sends a GET request to the specified `url` and returns a slice of the response content.
 // Allocation of the received response as a vstring is postponed until the `start` byte position is reached.
 // The content is returned as soon as the slice reaches its `max_size` (offset from `start`)
 // - `max_size` can be `none` to return the remainder from the start.
-pub fn (session Session) get_slice(url string, start usize, size ?usize) !Response {
-	return session.get_slice_(url, start, size)!
+pub fn (req Request) get_slice(url string, start usize, size ?usize) !Response {
+	return req.get_slice_(url, start, size)!
 }
 
 // Sends a HEAD request to the specified `url` and returns the response.
-pub fn (session Session) head(url string) !Response {
-	return session.head_(url)!
+pub fn (req Request) head(url string) !Response {
+	return req.head_(url)!
 }
 
 // Downloads a document from the specified `url` and saves it to the specified `file_path`.
-pub fn (session Session) download_file(url string, file_path string) !Response {
-	return session.download_file_(url, file_path)!
+pub fn (req Request) download_file(url string, file_path string) !Response {
+	return req.download_file_(url, file_path)!
 }
 
 // Sends a POST request to the specified `url` and returns the response.
-pub fn (session Session) post(url string, data string) !Response {
-	return session.post_(url, data)!
+pub fn (req Request) post(url string, data string) !Response {
+	return req.post_(url, data)!
 }
 
 // Returns the message associated with the status code.


### PR DESCRIPTION
* Automatizes init
* Simplifies API
* Allows usage of vibe with V's native concurrency

In the first version I hoped using session api will have significant enough performance benefits: initiating once per session and setting header for re-usage in subsequent requests. It turns out using calling curl_easy_init per request and setting options for every request - a common approach - has no noticeable performance loss.