### PR TITLE
feat!: declare `Download` as mut to allow custom mutable userdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ fn (dl Download) finish() {
 	println('\nDownload completed.')
 }
 
-request := vibe.Request{}
-request.download_file_with_progress('https://github.com/vlang/v/releases/download/weekly.2023.23/v_linux.zip',
-	'v_linux.zip', Download{})!
+mut dl := Download{}
+vibe.download_file_with_progress('https://github.com/vlang/v/releases/download/weekly.2023.23/v_linux.zip',
+	'v_linux.zip', mut dl)!
 ```
 
 **Persistent Cookie**

--- a/src/_instruction_download.v
+++ b/src/_instruction_download.v
@@ -33,7 +33,7 @@ fn (req Request) download_file_(url string, file_path string) !Response {
 	return resp
 }
 
-fn (req Request) download_file_with_progress_(url string, file_path string, dl Download) !Response {
+fn (req Request) download_file_with_progress_(url string, file_path string, mut dl Download) !Response {
 	h := curl.easy_init() or { return http_error(.easy_init, none) }
 	header := set_header(req.headers, h)
 	defer {

--- a/src/_state_download.v
+++ b/src/_state_download.v
@@ -16,6 +16,7 @@ mut:
 }
 
 interface Download {
+mut:
 	progress(u64, u64)
 	finish()
 }

--- a/src/lib.v
+++ b/src/lib.v
@@ -52,14 +52,14 @@ pub fn (req Request) download_file(url string, file_path string) !Response {
 
 // Downloads a document from the specified `url` and saves it to the specified `file_path`.
 // `download` must implement a `progress(pos u64, size u64)`, and a `finish()` method.
-pub fn download_file_with_progress(url string, file_path string, download Download) !Response {
-	return Request{}.download_file_with_progress_(url, file_path, download)!
+pub fn download_file_with_progress(url string, file_path string, mut download Download) !Response {
+	return Request{}.download_file_with_progress_(url, file_path, mut download)!
 }
 
 // Downloads a document from the specified `url` and saves it to the specified `file_path`.
 // `download` must implement a `progress(pos u64, size u64)`, and a `finish()` method.
-pub fn (req Request) download_file_with_progress(url string, file_path string, download Download) !Response {
-	return req.download_file_with_progress_(url, file_path, download)!
+pub fn (req Request) download_file_with_progress(url string, file_path string, mut download Download) !Response {
+	return req.download_file_with_progress_(url, file_path, mut download)!
 }
 
 // Sends a POST request to the specified `url` and returns the response.


### PR DESCRIPTION
Allows users to use mutable data in the `progress` / `finish` methods of the passed `Download`.

Example usage:

```v
import vibe
import bartender { Bar }

struct Download {
mut:
	bar Bar
}

fn (mut dl Download) progress(pos u64, size u64) {
	if (f64(pos) / size * dl.bar.width) > dl.bar.pos() {
		dl.bar.progress() or { panic(err) }
	}
}

fn (dl Download) finish() {
	println('Download completed.')
}

mut dl := Download{
	bar: Bar{}
}
vibe.download_file_with_progress('https://github.com/vlang/v/releases/download/weekly.2023.23/v_linux.zip',
	'v_linux.zip', mut dl)!
```