### PR TITLE
refactor: cleanup

### DIFF
--- a/src/_instructions_common.v
+++ b/src/_instructions_common.v
@@ -16,7 +16,7 @@ fn cleanup_() {
 	curl.global_cleanup()
 }
 
-fn (req Request) set_common_opts(h &C.CURL, url string, resp &Response) {
+fn (req Request) set_common_opts(h &C.CURL, url string, resp &VibeResponse) {
 	if req.cookie_jar != '' {
 		curl.easy_setopt(h, .cookiejar, req.cookie_jar)
 	}
@@ -57,12 +57,12 @@ fn send_request(handle &C.CURL) ! {
 	}
 }
 
-fn (mut resp Response) handle_redirect(h &C.CURL, max_redirects u16) ! {
+fn (mut resp VibeResponse) handle_redirect(h &C.CURL, max_redirects u16) ! {
 	mut status_code := 0
 	mut redir_url := ''.str
 
 	for _ in 0 .. max_redirects {
-		resp = Response{}
+		resp = VibeResponse{}
 		curl.easy_getinfo(h, .redirect_url, &redir_url)
 		curl.easy_setopt(h, .url, redir_url)
 		send_request(h)!

--- a/src/_instructions_head.v
+++ b/src/_instructions_head.v
@@ -10,30 +10,24 @@ fn (req Request) head_(url string) !Response {
 		curl.slist_free_all(header)
 	}
 
-	mut resp := req.head__(h, url)!
-
-	mut status_code := 0
-	curl.easy_getinfo(h, .response_code, &status_code)
-	resp.get_http_version()!
-	resp.status = Status(status_code)
-
-	return resp
-}
-
-// Follows redirects, sets the handle's URL opt to the latest URL of the redirected destination and sets header data.
-// Abstracted to also allow internal usage. E.g. before downloading to retrieve the head before an actual request.
-fn (req Request) head__(h &C.CURL, url string) !Response {
-	mut resp := Response{}
-	curl.easy_setopt(h, .writefunction, write_null)
-	curl.easy_setopt(h, .nobody, 1)
-	req.set_common_opts(h, url, &resp)
+	mut resp := VibeResponse{}
+	req.set_head_opts(h, url, &resp)
 	send_request(h)!
 
 	mut status_code := 0
 	curl.easy_getinfo(h, .response_code, &status_code)
 	if status_code / 100 == 3 {
 		resp.handle_redirect(h, req.max_redirects)!
+		curl.easy_getinfo(h, .response_code, &status_code)
 	}
+	resp.get_http_version()!
+	resp.status = Status(status_code)
 
-	return resp
+	return resp.Response
+}
+
+fn (req Request) set_head_opts(h &C.CURL, url string, resp &VibeResponse) {
+	curl.easy_setopt(h, .writefunction, write_null)
+	curl.easy_setopt(h, .nobody, 1)
+	req.set_common_opts(h, url, resp)
 }

--- a/src/_instructions_post.v
+++ b/src/_instructions_post.v
@@ -10,7 +10,7 @@ fn (req Request) post_(url string, data string) !Response {
 		curl.slist_free_all(header)
 	}
 
-	mut resp := Response{}
+	mut resp := VibeResponse{}
 	curl.easy_setopt(h, .post, 1)
 	curl.easy_setopt(h, .postfields, data)
 	curl.easy_setopt(h, .header, 1)
@@ -30,5 +30,5 @@ fn (req Request) post_(url string, data string) !Response {
 	resp.status = Status(status_code)
 	resp.body = resp.body[resp.header.len..]
 
-	return resp
+	return resp.Response
 }

--- a/src/_instructions_status.v
+++ b/src/_instructions_status.v
@@ -2,7 +2,7 @@ module vibe
 
 import strconv
 
-fn (mut resp Response) get_http_version() ! {
+fn (mut resp VibeResponse) get_http_version() ! {
 	status_line := resp.header.before('\r\n')
 
 	// Example: [0]: http/1.1 [1]: 200 [2]: OK

--- a/src/_instructions_write_fns.v
+++ b/src/_instructions_write_fns.v
@@ -1,6 +1,6 @@
 module vibe
 
-fn write_resp(data &char, size usize, nmemb usize, mut resp Response) usize {
+fn write_resp(data &char, size usize, nmemb usize, mut resp VibeResponse) usize {
 	n := size * nmemb
 	resp.pos += n
 	unsafe {
@@ -9,7 +9,7 @@ fn write_resp(data &char, size usize, nmemb usize, mut resp Response) usize {
 	return n
 }
 
-fn write_resp_header(data &char, size usize, nmemb usize, mut resp Response) usize {
+fn write_resp_header(data &char, size usize, nmemb usize, mut resp VibeResponse) usize {
 	n := size * nmemb
 	resp.pos += n
 	unsafe {
@@ -18,7 +18,7 @@ fn write_resp_header(data &char, size usize, nmemb usize, mut resp Response) usi
 	return n
 }
 
-fn write_resp_slice(data &char, size usize, nmemb usize, mut resp Response) usize {
+fn write_resp_slice(data &char, size usize, nmemb usize, mut resp VibeResponse) usize {
 	n := size * nmemb
 	resp.pos += n
 	if resp.pos > resp.slice.start {

--- a/src/_state_response.v
+++ b/src/_state_response.v
@@ -1,6 +1,15 @@
 module vibe
 
 pub struct Response {
+pub mut:
+	header       string
+	status       Status
+	http_version string
+	body         string
+}
+
+struct VibeResponse {
+	Response
 mut:
 	pos   usize
 	slice struct {
@@ -9,9 +18,4 @@ mut:
 	mut:
 		finished bool
 	}
-pub mut:
-	header       string
-	status       Status
-	http_version string
-	body         string
 }


### PR DESCRIPTION
- Don't expose response fields only relevant for internal use.
- Move `head__` to `_instruction_download.v` as `follow_download_head`.
- Abstract set download opts - light version of earlier error prone abstraction in e3899adc7e6c238eb3d67499bcec00be9c056535, without using a sumtype.
- Set `.writefunction` in `get` / `get_slice` methods to remove an unnecessary conditional check in `set_get_opts`.