### PR TITLE
chore: use relative import paths, as it is now supported

### DIFF
--- a/curl/instructions/common.v
+++ b/curl/instructions/common.v
@@ -1,6 +1,6 @@
 module instructions
 
-import vibe.curl.state
+import state
 
 fn C.curl_global_init(state.GlobalInitFlag)
 

--- a/curl/instructions/easy.v
+++ b/curl/instructions/easy.v
@@ -1,6 +1,6 @@
 module instructions
 
-import vibe.curl.state
+import state
 
 fn C.curl_easy_init() &C.CURL
 fn C.curl_easy_cleanup(&C.CURL)

--- a/curl/lib.v
+++ b/curl/lib.v
@@ -5,8 +5,8 @@ License: MIT
 
 module curl
 
-import vibe.curl.instructions
-import vibe.curl.state
+import instructions
+import state
 
 #flag -lcurl
 #include <curl/curl.h>

--- a/src/_instruction_download.v
+++ b/src/_instruction_download.v
@@ -1,7 +1,7 @@
 module vibe
 
 import os
-import vibe.curl
+import curl
 
 fn (req Request) download_file_(url string, file_path string) !Response {
 	h := curl.easy_init() or { return http_error(.easy_init, none) }

--- a/src/_instructions_common.v
+++ b/src/_instructions_common.v
@@ -1,6 +1,6 @@
 module vibe
 
-import vibe.curl
+import curl
 
 // Automatically call curl_global_init when using `vibe`.
 fn init() {

--- a/src/_instructions_get.v
+++ b/src/_instructions_get.v
@@ -1,6 +1,6 @@
 module vibe
 
-import vibe.curl
+import curl
 
 fn (req Request) get_(url string) !Response {
 	// Curl handle

--- a/src/_instructions_head.v
+++ b/src/_instructions_head.v
@@ -1,6 +1,6 @@
 module vibe
 
-import vibe.curl
+import curl
 
 fn (req Request) head_(url string) !Response {
 	h := curl.easy_init() or { return http_error(.easy_init, none) }

--- a/src/_instructions_header.v
+++ b/src/_instructions_header.v
@@ -1,6 +1,6 @@
 module vibe
 
-import vibe.curl
+import curl
 
 fn set_header(handle &curl.Handle, headers HttpHeaders) &curl.LinkedList {
 	mut list := &curl.LinkedList(unsafe { nil })

--- a/src/_instructions_post.v
+++ b/src/_instructions_post.v
@@ -1,6 +1,6 @@
 module vibe
 
-import vibe.curl
+import curl
 
 fn (req Request) post_(url string, data string) !Response {
 	h := curl.easy_init() or { return http_error(.easy_init, none) }


### PR DESCRIPTION
A change that should also extend usability, allowing to keep the module in a relative location instead of the modules dir.